### PR TITLE
Update feature display via api

### DIFF
--- a/almanac_browser/__init__.py
+++ b/almanac_browser/__init__.py
@@ -32,6 +32,7 @@ def create_app(name=__name__):
     app.register_blueprint(api, url_prefix='/api')
     # app.register_blueprint(editor, url_prefix='/editor')
     app.register_blueprint(portal)
+    app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
 
     db.init_app(app)
     ma.init_app(app)  # must initialize after SQLAlchemy


### PR DESCRIPTION
The api endpoints to display features have been updated to display values instead of indexes. 

Previously, https://moalmanac.org/api/features/1 returned 
```
{
  "attributes": [
    {
      "value": "Fusion"
    }, 
    {
      "value": "BCR"
    }, 
    {
      "value": "ABL1"
    }, 
    {
      "value": null
    }
  ], 
  "feature_definition": {
    "attribute_definitions": [
      {
        "name": "rearrangement_type"
      }, 
      {
        "name": "gene1"
      }, 
      {
        "name": "gene2"
      }, 
      {
        "name": "locus"
      }
    ], 
    "name": "rearrangement"
  }, 
  "feature_id": 1
}
```

And it now returns 
```
{
  "attributes": [
    {
      "feature_type": "rearrangement", 
      "gene1": "BCR", 
      "gene2": "ABL1", 
      "locus": null, 
      "rearrangement_type": "Fusion"
    }
  ], 
  "feature_type": "rearrangement"
}
```

This should be more readable to users and is a "lock" of our API, no further changes are currently planned. This format allows for flexibility for the future feature type "connections" which will store multiple molecular features within the attributes list as records. 