### PR TITLE
Add traffic analytics

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
 {% block head %}
     {{super()}}
     {{fixes.ie8()}}
+    {% include 'traffic.html' %}
 {% endblock %}
 
 {% block styles %}

--- a/templates/privacy_policy.html
+++ b/templates/privacy_policy.html
@@ -1,5 +1,5 @@
 <p>
-    <strong>Effective date: July 12th, 2021</strong>
+    <strong>Effective date: July 12th, 2023</strong>
 </p>
 <p>
     The Van Allen Lab at Dana-Farber Cancer Institute and Broad Institute ("us", "we", or "our") operates the Molecular Oncology Almanac browser (<a href="https://moalmanac.org">https://moalmanac.org</a>) and the Molecular Oncology Almanac Connector, a Chrome extension (hereinafter referred to jointly as the "Service"). The Service is to be used to suggest contributions to the precision oncology database, Molecular Oncology Almanac.

--- a/templates/privacy_policy.html
+++ b/templates/privacy_policy.html
@@ -1,5 +1,5 @@
 <p>
-    <strong>Effective date: April 29, 2021</strong>
+    <strong>Effective date: July 12th, 2021</strong>
 </p>
 <p>
     The Van Allen Lab at Dana-Farber Cancer Institute and Broad Institute ("us", "we", or "our") operates the Molecular Oncology Almanac browser (<a href="https://moalmanac.org">https://moalmanac.org</a>) and the Molecular Oncology Almanac Connector, a Chrome extension (hereinafter referred to jointly as the "Service"). The Service is to be used to suggest contributions to the precision oncology database, Molecular Oncology Almanac.
@@ -20,7 +20,7 @@
 
 <h3>Information Collection and Use</h3>
 <p>
-    We collect serveral different types of information for various purposes to provide and improve our Service to you.
+    We collect several different types of information for various purposes to provide and improve our Service to you.
     <br>
     <h4>Types of Data Collected</h4>
     <h5>Personal Data</h5>
@@ -42,7 +42,7 @@
         <li>To provide user care and support</li>
         <li>To provide analysis or valuable information so that we can improve the Service</li>
         <li>To monitor the usage of the Service</li>
-        <li>To detect, prevent and address techniacl issues</li>
+        <li>To detect, prevent and address technical issues</li>
     </ul>
 </p>
 
@@ -53,6 +53,11 @@
     By submitting your information, including Personal Data, as part of the Service, you consent to abide and be bound by this Privacy Policy.
     <br><br>
     Molecular Oncology Almanac Connector will take all steps reasonably necessary in accordance with United States law to ensure that your data is treated securely and in accordance with this Privacy Policy.
+</p>
+
+<h3>Analytics Partners</h3>
+<p>
+    We use a GDPR, CCPA, and cookie law compliant site analytics tool, <a href="https://plausible.io/">Plausible Analytics</a>, to track overall trends in the usage of our website. Plausible Analytics collects only aggregated information, no cookies are used, and no personal data - not even an IP address or browser user agent - is stored. To help us understand how you use our Services and to help us improve them, we automatically receive information about your interactions with our Service, such as the pages or other content you view and the dates and times of your visits. For more information about how Plausible Analytics handles data, please review the <a href="https://plausible.io/data-policy">Plausible Analytics Data Policy</a>.
 </p>
 
 <h3>Disclosure of Data</h3>

--- a/templates/traffic.html
+++ b/templates/traffic.html
@@ -1,0 +1,1 @@
+<script defer data-domain="moalmanac.org" src="https://plausible.io/js/script.js"></script>


### PR DESCRIPTION
We have added traffic analytics to moalmanac.org using [Plausible Analytics](https://plausible.io/).   

Additionally, we have revised our privacy policy to reflect this change,
> **Analytics Partners**
>  We use a GDPR, CCPA, and cookie law compliant site analytics tool, <a href="https://plausible.io/">Plausible Analytics</a>, to track overall trends in the usage of our website. Plausible Analytics collects only aggregated information, no cookies are used, and no personal data - not even an IP address or browser user agent - is stored. To help us understand how you use our Services and to help us improve them, we automatically receive information about your interactions with our Service, such as the pages or other content you view and the dates and times of your visits. For more information about how Plausible Analytics handles data, please review the <a href="https://plausible.io/data-policy">Plausible Analytics Data Policy</a>.
